### PR TITLE
first pass at pushing executable blocks from sync to contract runtime

### DIFF
--- a/node/src/components/block_synchronizer.rs
+++ b/node/src/components/block_synchronizer.rs
@@ -100,6 +100,20 @@ impl BlockSynchronizer {
     }
 
     // CALLED FROM REACTOR
+    pub(crate) fn all_executable_block_hashes(&self) -> Vec<(u64, BlockHash)> {
+        let mut ret: Vec<(u64, BlockHash)> = vec![];
+        for (block_hash, builder) in &self.builders {
+            if builder.is_complete() == false {
+                continue;
+            }
+            if let Some(block_height) = builder.block_height() {
+                ret.push((block_height, *block_hash));
+            }
+        }
+        ret
+    }
+
+    // CALLED FROM REACTOR
     pub(crate) fn register_block_by_hash(
         &mut self,
         block_hash: BlockHash,
@@ -332,6 +346,8 @@ impl BlockSynchronizer {
                     }))
                 }
                 NeedNext::ExecutionResults(Need::ShouldStore(execution_results)) => {
+                    // Fraser, I straight up don't like this approach on several levels;
+                    // would like to discuss tomorrow
                     let block_hash = builder.block_hash();
                     let execution_results = execution_results
                         .into_iter()

--- a/node/src/components/block_synchronizer/block_acquisition.rs
+++ b/node/src/components/block_synchronizer/block_acquisition.rs
@@ -8,7 +8,6 @@ use datasize::DataSize;
 use casper_hashing::Digest;
 use casper_types::{EraId, PublicKey};
 
-use crate::types::BlockExecutionResultsOrChunk;
 use crate::{
     components::block_synchronizer::{
         deploy_acquisition::{DeployAcquisition, DeployState},
@@ -19,8 +18,8 @@ use crate::{
         ExecutionResultsAcquisition, ExecutionResultsRootHash,
     },
     types::{
-        Block, BlockHash, BlockHeader, DeployHash, EraValidatorWeights, FinalitySignature, Item,
-        NodeId, SignatureWeight,
+        Block, BlockExecutionResultsOrChunk, BlockHash, BlockHeader, DeployHash,
+        EraValidatorWeights, FinalitySignature, Item, NodeId, SignatureWeight,
     },
     NodeRng,
 };

--- a/node/src/components/block_synchronizer/block_builder.rs
+++ b/node/src/components/block_synchronizer/block_builder.rs
@@ -12,7 +12,6 @@ use crate::components::block_synchronizer::{
 use casper_hashing::Digest;
 use casper_types::{EraId, Timestamp};
 
-use crate::types::BlockExecutionResultsOrChunk;
 use crate::{
     components::block_synchronizer::{
         deploy_acquisition::DeployAcquisition,
@@ -22,8 +21,8 @@ use crate::{
         signature_acquisition::SignatureAcquisition,
     },
     types::{
-        BlockAdded, BlockHash, BlockHeader, DeployHash, EraValidatorWeights, FinalitySignature,
-        NodeId, SyncLeap,
+        BlockAdded, BlockExecutionResultsOrChunk, BlockHash, BlockHeader, DeployHash,
+        EraValidatorWeights, FinalitySignature, NodeId, SyncLeap,
     },
     NodeRng,
 };

--- a/node/src/components/block_synchronizer/event.rs
+++ b/node/src/components/block_synchronizer/event.rs
@@ -12,12 +12,12 @@ use casper_execution_engine::core::engine_state;
 use casper_types::{EraId, PublicKey, U512};
 
 use super::GlobalStateSynchronizerEvent;
-use crate::types::BlockExecutionResultsOrChunk;
 use crate::{
     components::{block_synchronizer::GlobalStateSynchronizerError, fetcher::FetchResult},
     effect::requests::BlockSynchronizerRequest,
     types::{
-        BlockAdded, BlockHash, BlockHeader, Deploy, EraValidatorWeights, FinalitySignature, NodeId,
+        BlockAdded, BlockExecutionResultsOrChunk, BlockHash, BlockHeader, Deploy,
+        EraValidatorWeights, FinalitySignature, NodeId,
     },
 };
 

--- a/node/src/components/block_synchronizer/need_next.rs
+++ b/node/src/components/block_synchronizer/need_next.rs
@@ -3,8 +3,8 @@ use datasize::DataSize;
 use casper_hashing::Digest;
 use casper_types::{EraId, PublicKey};
 
-use crate::types::{BlockHash, DeployHash};
 use super::execution_results_acquisition::Need;
+use crate::types::{BlockHash, DeployHash};
 
 #[derive(DataSize, Debug, Clone)]
 pub(crate) enum NeedNext {

--- a/node/src/components/blocks_accumulator.rs
+++ b/node/src/components/blocks_accumulator.rs
@@ -17,7 +17,10 @@ use crate::{
     NodeRng,
 };
 
-use crate::{effect::requests::BlocksAccumulatorRequest, types::BlockHeader};
+use crate::{
+    effect::requests::BlocksAccumulatorRequest,
+    types::{BlockHeader, BlockPayload, DeployHash, FinalizedBlock},
+};
 use block_gossip_acceptor::BlockGossipAcceptor;
 use error::Error;
 pub(crate) use event::Event;
@@ -299,6 +302,14 @@ impl BlocksAccumulator {
         {
             self.block_gossip_acceptors.remove(&block_hash);
             self.filter.push(block_hash);
+        }
+    }
+
+    pub(crate) fn block_added(&self, block_hash: BlockHash) -> Option<BlockAdded> {
+        if let Some(acceptor) = self.block_gossip_acceptors.get(&block_hash) {
+            acceptor.block_added()
+        } else {
+            None
         }
     }
 

--- a/node/src/components/blocks_accumulator/block_gossip_acceptor.rs
+++ b/node/src/components/blocks_accumulator/block_gossip_acceptor.rs
@@ -293,6 +293,10 @@ impl BlockGossipAcceptor {
         self.block_hash
     }
 
+    pub(super) fn block_added(&self) -> Option<BlockAdded> {
+        self.block_added.clone()
+    }
+
     pub(super) fn has_era_validator_weights(&self) -> bool {
         self.era_validator_weights.is_some()
     }

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -1074,8 +1074,8 @@ pub(crate) enum ContractRuntimeRequest {
         /// Responder to call with the result.
         responder: Responder<Result<GetBidsResult, engine_state::Error>>,
     },
-    /// Returns the value of the deploys' approvals root hash stored in the ChecksumRegistry for the
-    /// given state root hash.
+    /// Returns the value of the deploys' approvals root hash stored in the ChecksumRegistry for
+    /// the given state root hash.
     GetApprovalsRootHash {
         state_root_hash: Digest,
         responder: Responder<Result<Option<Digest>, engine_state::Error>>,

--- a/node/src/reactor/main_reactor/control.rs
+++ b/node/src/reactor/main_reactor/control.rs
@@ -25,8 +25,8 @@ use crate::{
         MainEvent, MainReactor,
     },
     types::{
-        ActivationPoint, BlockHash, BlockHeader, BlockPayload, ChainspecRawBytes,
-        EraValidatorWeights, FinalizedBlock, Item, ValidatorMatrix,
+        ActivationPoint, BlockAdded, BlockHash, BlockHeader, BlockPayload, ChainspecRawBytes,
+        DeployHash, EraValidatorWeights, FinalizedBlock, Item, ValidatorMatrix,
     },
     NodeRng,
 };
@@ -257,12 +257,21 @@ impl MainReactor {
                                 self.block_synchronizer.turn_off();
                             }
                         }
-                        // Fraser...maybe this would be more practical?
-                        /*
-                            self.contract_runtime.enqueue_executable_blocks(
-                                self.block_synchronizer.get_executable_blocks()
-                            );
-                        */
+                        match self.enqueue_executable_blocks(effect_builder) {
+                            Ok(mut effects) => {
+                                effects.extend(
+                                    effect_builder
+                                        .immediately()
+                                        .event(|_| MainEvent::ReactorCrank),
+                                );
+                                return effects;
+                            }
+                            Err(msg) => {
+                                return effect_builder
+                                    .immediately()
+                                    .event(move |_| MainEvent::Shutdown(msg));
+                            }
+                        }
                     }
                 }
             }
@@ -606,5 +615,64 @@ impl MainReactor {
             },
             Err(msg) => Err(msg),
         }
+    }
+
+    pub(crate) fn enqueue_executable_blocks(
+        &mut self,
+        effect_builder: EffectBuilder<MainEvent>,
+    ) -> Result<Effects<MainEvent>, String> {
+        let mut effects = Effects::new();
+        let mut executable_block_hashes = self.block_synchronizer.all_executable_block_hashes();
+        executable_block_hashes.sort_by(|x, y| x.0.cmp(&y.0));
+        for (height, block_hash) in executable_block_hashes {
+            if let Some(block_added) = self.blocks_accumulator.block_added(block_hash) {
+                match self.storage.make_executable_block(block_added) {
+                    Ok(Some((finalized_block, deploys, transfers))) => {
+                        effects.extend(
+                            effect_builder
+                                .enqueue_block_for_execution(finalized_block, deploys, transfers)
+                                .ignore(),
+                        );
+                    }
+                    Ok(None) => {
+                        // noop
+                    }
+                    Err(_) => {
+                        return Err(format!(
+                            "failure to make block_added into executable block: {}",
+                            block_hash
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(effects)
+    }
+
+    pub(crate) fn enqueue_executable_blocks_alt(
+        &mut self,
+        effect_builder: EffectBuilder<MainEvent>,
+    ) -> Result<Effects<MainEvent>, String> {
+        let mut effects = Effects::new();
+        let mut executable_block_hashes = self.block_synchronizer.all_executable_block_hashes();
+        executable_block_hashes.sort_by(|x, y| x.0.cmp(&y.0));
+        for (height, block_hash) in executable_block_hashes {
+            match self.storage.make_finalized_block(block_hash) {
+                Ok(Some((finalized_block, deploys, transfers))) => {
+                    effects.extend(
+                        effect_builder
+                            .enqueue_block_for_execution(finalized_block, deploys, transfers)
+                            .ignore(),
+                    );
+                }
+                Ok(None) => {
+                    // noop
+                }
+                Err(_) => {
+                    return Err(format!("failure to fetch block: {}", block_hash));
+                }
+            }
+        }
+        Ok(effects)
     }
 }

--- a/node/src/types/sync_leap.rs
+++ b/node/src/types/sync_leap.rs
@@ -174,8 +174,8 @@ impl FetcherItem for SyncLeap {
 
         // The header chain should only go back until it hits _one_ switch block.
         for header in self.trusted_ancestor_headers.iter().rev().skip(1) {
-                if header.is_switch_block() {
-                    return Err(SyncLeapValidationError::UnexpectedSwitchBlock);
+            if header.is_switch_block() {
+                return Err(SyncLeapValidationError::UnexpectedSwitchBlock);
             }
         }
 


### PR DESCRIPTION
* a couple of broad-stroke variations to reverse engineer a finalized block from block sync or block accum, final approach to be discussed with the gang
* tweak to BlockAdded to provide map of deploy_hash to approvals for that deploy

