### PR TITLE
More memoization; remember finality signature senders

### DIFF
--- a/node/src/components/block_accumulator/error.rs
+++ b/node/src/components/block_accumulator/error.rs
@@ -42,11 +42,10 @@ pub(super) enum Error {
         actual: EraId,
         peer: NodeId,
     },
-    #[error("mismatched block hash from peer {peer}: expected={expected}, actual={actual}")]
+    #[error("mismatched block hash: expected={expected}, actual={actual}")]
     BlockHashMismatch {
         expected: BlockHash,
         actual: BlockHash,
-        peer: NodeId,
     },
     #[error("should not be possible to have sufficient finality wihtout block: {block_hash}")]
     SufficientFinalityWithoutBlock { block_hash: BlockHash },

--- a/node/src/components/block_synchronizer/trie_accumulator.rs
+++ b/node/src/components/block_synchronizer/trie_accumulator.rs
@@ -134,7 +134,7 @@ impl TrieAccumulator {
                 }
                 Some(partial_chunks) => {
                     debug!(%hash, "got a full trie");
-                    partial_chunks.respond(Ok(Box::new(trie)))
+                    partial_chunks.respond(Ok(Box::new(trie.into_inner())))
                 }
             },
             TrieOrChunk::ChunkWithProof(chunk) => self.consume_chunk(effect_builder, chunk),

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -850,7 +850,7 @@ impl ContractRuntime {
         let TrieOrChunkId(chunk_index, trie_key) = trie_or_chunk_id;
         let ret = match engine_state.get_trie_full(correlation_id, trie_key)? {
             None => Ok(None),
-            Some(trie_raw) => Ok(Some(TrieOrChunk::new(trie_raw, chunk_index)?)),
+            Some(trie_raw) => Ok(Some(TrieOrChunk::new(trie_raw.into(), chunk_index)?)),
         };
         metrics.get_trie.observe(start.elapsed().as_secs_f64());
         ret
@@ -925,9 +925,10 @@ mod tests {
 
     fn extract_next_hash_from_trie(trie_or_chunk: TrieOrChunk) -> Digest {
         let next_hash = if let TrieOrChunk::Value(trie_bytes) = trie_or_chunk {
-            if let Trie::Node { pointer_block } =
-                bytesrepr::deserialize::<Trie<Key, StoredValue>>(trie_bytes.into_inner().into())
-                    .expect("Could not parse trie bytes")
+            if let Trie::Node { pointer_block } = bytesrepr::deserialize::<Trie<Key, StoredValue>>(
+                trie_bytes.into_inner().into_inner().into(),
+            )
+            .expect("Could not parse trie bytes")
             {
                 if pointer_block.child_count() == 0 {
                     panic!("expected children");

--- a/node/src/types/chunkable.rs
+++ b/node/src/types/chunkable.rs
@@ -1,11 +1,13 @@
 use std::{borrow::Cow, convert::Infallible};
 
-use casper_execution_engine::storage::trie::TrieRaw;
 use casper_hashing::Digest;
+use casper_types::bytesrepr::ToBytes;
 use casper_types::{
     bytesrepr::{self, Bytes},
     ExecutionResult,
 };
+
+use super::value_or_chunk::HashingTrieRaw;
 
 /// Implemented for types that are chunked when sending over the wire and/or before storing the the
 /// trie store.
@@ -45,13 +47,11 @@ impl Chunkable for Bytes {
     }
 }
 
-use casper_types::bytesrepr::ToBytes;
-
-impl Chunkable for TrieRaw {
+impl Chunkable for HashingTrieRaw {
     type Error = Infallible;
 
     fn as_bytes(&self) -> Result<Cow<Vec<u8>>, Self::Error> {
-        Ok(Cow::Borrowed(self.inner().inner_bytes()))
+        Ok(Cow::Borrowed(self.inner().inner().inner_bytes()))
     }
 }
 

--- a/node/src/types/value_or_chunk.rs
+++ b/node/src/types/value_or_chunk.rs
@@ -20,7 +20,7 @@ use crate::types::{EmptyValidationMetadata, FetcherItem, Item, Tag};
 /// value is larger than [ChunkWithProof::CHUNK_SIZE_BYTES].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, DataSize)]
 pub enum ValueOrChunk<V> {
-    /// Represents a value.
+    /// Represents a value. The second entry is the memoized hash.
     Value(V),
     /// Represents a chunk of data with attached proof.
     ChunkWithProof(ChunkWithProof),


### PR DESCRIPTION
Memoizes `BlockBody::hash`, `BlockExecutionResultsOrChunk::validate` and `TrieRaw`'s hash.

The block accumulator now remembers from whom we received each finality signature. If it later turns out to be invalid (wrong era ID or signed by non-validator), we disconnect from the sender.
