### PR TITLE
Prune recent_switch_block_headers.

### DIFF
--- a/node/src/components/consensus/era_supervisor.rs
+++ b/node/src/components/consensus/era_supervisor.rs
@@ -184,9 +184,18 @@ impl EraSupervisor {
         rng: &mut NodeRng,
         recent_switch_block_headers: &[BlockHeader],
     ) -> Option<Effects<Event>> {
+        if !recent_switch_block_headers
+            .iter()
+            .tuple_windows()
+            .all(|(b0, b1)| b0.next_block_era_id() == b1.era_id())
+        {
+            error!("switch block headers are not consecutive; this is a bug");
+            return None;
+        }
+
         let highest_switch_block_header = recent_switch_block_headers.last()?;
 
-        let new_era_id = highest_switch_block_header.era_id().successor();
+        let new_era_id = highest_switch_block_header.next_block_era_id();
 
         // We need to initialize current_era and (evidence-only) current_era - 1.
         // To initialize an era, all switch blocks between its booking block and its key block are

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -659,6 +659,11 @@ impl reactor::Reactor for MainReactor {
                             .recent_switch_block_headers
                             .push(block.header().clone()),
                     }
+
+                    let era_count = self.chainspec.number_of_past_switch_blocks_needed();
+                    while self.recent_switch_block_headers.len() as u64 > era_count {
+                        self.recent_switch_block_headers.remove(0);
+                    }
                 }
                 debug!(
                     "notifying block gossiper to start gossiping for: {}",

--- a/node/src/types/value_or_chunk.rs
+++ b/node/src/types/value_or_chunk.rs
@@ -24,7 +24,7 @@ use crate::{
 /// value is larger than [ChunkWithProof::CHUNK_SIZE_BYTES].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, DataSize)]
 pub enum ValueOrChunk<V> {
-    /// Represents a value. The second entry is the memoized hash.
+    /// Represents a value.
     Value(V),
     /// Represents a chunk of data with attached proof.
     ChunkWithProof(ChunkWithProof),


### PR DESCRIPTION
Retains only those recent switch block headers in memory that are needed to initialize the next era.

Addresses https://github.com/Fraser999/casper-node/pull/105#discussion_r1016535577.

Closes [#3346](https://github.com/casper-network/casper-node/issues/3346).